### PR TITLE
Update snapshots for Vitest 3

### DIFF
--- a/src/components/Box/__snapshots__/Box.spec.tsx.snap
+++ b/src/components/Box/__snapshots__/Box.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Box > it works with elevations 1`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -11,7 +11,7 @@ exports[`Box > it works with elevations 1`] = `
 
 exports[`Box > it works with elevations 2`] = `
 <div
-  class="_this_d62db4 _elevation-small_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-small_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -20,7 +20,7 @@ exports[`Box > it works with elevations 2`] = `
 
 exports[`Box > it works with elevations 3`] = `
 <div
-  class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -29,7 +29,7 @@ exports[`Box > it works with elevations 3`] = `
 
 exports[`Box > it works with elevations 4`] = `
 <div
-  class="_this_d62db4 _elevation-large_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-large_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -38,7 +38,7 @@ exports[`Box > it works with elevations 4`] = `
 
 exports[`Box > it works with gutterXs 1`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -47,7 +47,7 @@ exports[`Box > it works with gutterXs 1`] = `
 
 exports[`Box > it works with gutterXs 2`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-small_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-small_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -56,7 +56,7 @@ exports[`Box > it works with gutterXs 2`] = `
 
 exports[`Box > it works with gutterXs 3`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-medium_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-medium_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -65,7 +65,7 @@ exports[`Box > it works with gutterXs 3`] = `
 
 exports[`Box > it works with gutterXs 4`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-large_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-large_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -74,7 +74,7 @@ exports[`Box > it works with gutterXs 4`] = `
 
 exports[`Box > it works with gutterYs 1`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -83,7 +83,7 @@ exports[`Box > it works with gutterYs 1`] = `
 
 exports[`Box > it works with gutterYs 2`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-small_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-small_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -92,7 +92,7 @@ exports[`Box > it works with gutterYs 2`] = `
 
 exports[`Box > it works with gutterYs 3`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -101,7 +101,7 @@ exports[`Box > it works with gutterYs 3`] = `
 
 exports[`Box > it works with gutterYs 4`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-large_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-large_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -110,7 +110,7 @@ exports[`Box > it works with gutterYs 4`] = `
 
 exports[`Box > it works with gutters 1`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -119,7 +119,7 @@ exports[`Box > it works with gutters 1`] = `
 
 exports[`Box > it works with gutters 2`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-small_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-small_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -128,7 +128,7 @@ exports[`Box > it works with gutters 2`] = `
 
 exports[`Box > it works with gutters 3`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -137,7 +137,7 @@ exports[`Box > it works with gutters 3`] = `
 
 exports[`Box > it works with gutters 4`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-large_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-large_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -146,7 +146,7 @@ exports[`Box > it works with gutters 4`] = `
 
 exports[`Box > it works with roundness 1`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -155,7 +155,7 @@ exports[`Box > it works with roundness 1`] = `
 
 exports[`Box > it works with roundness 2`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-small_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-small_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -164,7 +164,7 @@ exports[`Box > it works with roundness 2`] = `
 
 exports[`Box > it works with roundness 3`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-medium_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-medium_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world
@@ -173,7 +173,7 @@ exports[`Box > it works with roundness 3`] = `
 
 exports[`Box > it works with roundness 4`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-large_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-large_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
   data-testid="Box"
 >
   Hello world

--- a/src/components/Button/__snapshots__/Button.spec.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.spec.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`Button > it works block 1`] = `
 <button
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296 _block_f8f296"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7 _block_ee73f7"
   data-testid="Button"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-primary_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-primary_ee73f7"
     data-testid="Button-inner"
   >
     Hello world
@@ -16,12 +16,12 @@ exports[`Button > it works block 1`] = `
 
 exports[`Button > it works disabled 1`] = `
 <button
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7"
   data-testid="Button"
   disabled=""
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-primary_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-primary_ee73f7"
     data-testid="Button-inner"
   >
     Hello world
@@ -31,11 +31,11 @@ exports[`Button > it works disabled 1`] = `
 
 exports[`Button > it works with defaults 1`] = `
 <button
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7"
   data-testid="Button"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-primary_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-primary_ee73f7"
     data-testid="Button-inner"
   >
     Hello world
@@ -45,11 +45,11 @@ exports[`Button > it works with defaults 1`] = `
 
 exports[`Button > it works with icon 1`] = `
 <button
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7"
   data-testid="Button"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-primary_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-primary_ee73f7"
     data-testid="Button-inner"
   >
     <svg
@@ -74,11 +74,11 @@ exports[`Button > it works with icon 1`] = `
 
 exports[`Button > it works with levels 1`] = `
 <button
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7"
   data-testid="Button"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-primary_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-primary_ee73f7"
     data-testid="Button-inner"
   >
     Hello world
@@ -88,11 +88,11 @@ exports[`Button > it works with levels 1`] = `
 
 exports[`Button > it works with levels 2`] = `
 <button
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7"
   data-testid="Button"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-secondary_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-secondary_ee73f7"
     data-testid="Button-inner"
   >
     Hello world
@@ -102,11 +102,11 @@ exports[`Button > it works with levels 2`] = `
 
 exports[`Button > it works with levels 3`] = `
 <button
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7"
   data-testid="Button"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-tertiary_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-tertiary_ee73f7"
     data-testid="Button-inner"
   >
     Hello world
@@ -116,11 +116,11 @@ exports[`Button > it works with levels 3`] = `
 
 exports[`Button > it works with levels 4`] = `
 <button
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7"
   data-testid="Button"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-danger_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-danger_ee73f7"
     data-testid="Button-inner"
   >
     Hello world
@@ -130,11 +130,11 @@ exports[`Button > it works with levels 4`] = `
 
 exports[`Button > it works with sizes 1`] = `
 <button
-  class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296"
+  class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7"
   data-testid="Button"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-small_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-primary_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-small_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-primary_ee73f7"
     data-testid="Button-inner"
   >
     Hello world
@@ -144,11 +144,11 @@ exports[`Button > it works with sizes 1`] = `
 
 exports[`Button > it works with sizes 2`] = `
 <button
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7"
   data-testid="Button"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-primary_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-primary_ee73f7"
     data-testid="Button-inner"
   >
     Hello world
@@ -158,11 +158,11 @@ exports[`Button > it works with sizes 2`] = `
 
 exports[`Button > it works with sizes 3`] = `
 <button
-  class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_f8f296"
+  class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_ee73f7"
   data-testid="Button"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-large_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_f8f296 _level-primary_f8f296"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-large_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ee73f7 _level-primary_ee73f7"
     data-testid="Button-inner"
   >
     Hello world

--- a/src/components/Heading/__snapshots__/Heading.spec.tsx.snap
+++ b/src/components/Heading/__snapshots__/Heading.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Heading > it works with defaults 1`] = `
 <h1
-  class="_this_b26e6e _size-medium_b26e6e _family-heading_b26e6e _weight-medium_b26e6e _this_2bdcc0 _size-large_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-heading_d6c5f6 _weight-medium_d6c5f6 _this_1e8633 _size-large_1e8633"
   data-testid="Heading"
 >
   Hello world
@@ -11,7 +11,7 @@ exports[`Heading > it works with defaults 1`] = `
 
 exports[`Heading > it works with families 1`] = `
 <h1
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_2bdcc0 _size-large_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_1e8633 _size-large_1e8633"
   data-testid="Heading"
 >
   Hello world
@@ -20,7 +20,7 @@ exports[`Heading > it works with families 1`] = `
 
 exports[`Heading > it works with families 2`] = `
 <h1
-  class="_this_b26e6e _size-medium_b26e6e _family-heading_b26e6e _weight-medium_b26e6e _this_2bdcc0 _size-large_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-heading_d6c5f6 _weight-medium_d6c5f6 _this_1e8633 _size-large_1e8633"
   data-testid="Heading"
 >
   Hello world
@@ -29,7 +29,7 @@ exports[`Heading > it works with families 2`] = `
 
 exports[`Heading > it works with families 3`] = `
 <h1
-  class="_this_b26e6e _size-medium_b26e6e _family-serif_b26e6e _weight-medium_b26e6e _this_2bdcc0 _size-large_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-serif_d6c5f6 _weight-medium_d6c5f6 _this_1e8633 _size-large_1e8633"
   data-testid="Heading"
 >
   Hello world
@@ -38,7 +38,7 @@ exports[`Heading > it works with families 3`] = `
 
 exports[`Heading > it works with families 4`] = `
 <h1
-  class="_this_b26e6e _size-medium_b26e6e _family-mono_b26e6e _weight-medium_b26e6e _this_2bdcc0 _size-large_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-mono_d6c5f6 _weight-medium_d6c5f6 _this_1e8633 _size-large_1e8633"
   data-testid="Heading"
 >
   Hello world
@@ -47,7 +47,7 @@ exports[`Heading > it works with families 4`] = `
 
 exports[`Heading > it works with sizes 1`] = `
 <h1
-  class="_this_b26e6e _size-medium_b26e6e _family-heading_b26e6e _weight-medium_b26e6e _this_2bdcc0 _size-large_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-heading_d6c5f6 _weight-medium_d6c5f6 _this_1e8633 _size-large_1e8633"
   data-testid="Heading"
 >
   Hello world
@@ -56,7 +56,7 @@ exports[`Heading > it works with sizes 1`] = `
 
 exports[`Heading > it works with sizes 2`] = `
 <h2
-  class="_this_b26e6e _size-medium_b26e6e _family-heading_b26e6e _weight-medium_b26e6e _this_2bdcc0 _size-medium_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-heading_d6c5f6 _weight-medium_d6c5f6 _this_1e8633 _size-medium_1e8633"
   data-testid="Heading"
 >
   Hello world
@@ -65,7 +65,7 @@ exports[`Heading > it works with sizes 2`] = `
 
 exports[`Heading > it works with sizes 3`] = `
 <h3
-  class="_this_b26e6e _size-medium_b26e6e _family-heading_b26e6e _weight-medium_b26e6e _this_2bdcc0 _size-small_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-heading_d6c5f6 _weight-medium_d6c5f6 _this_1e8633 _size-small_1e8633"
   data-testid="Heading"
 >
   Hello world
@@ -74,7 +74,7 @@ exports[`Heading > it works with sizes 3`] = `
 
 exports[`Heading > it works with weights 1`] = `
 <h1
-  class="_this_b26e6e _size-medium_b26e6e _family-heading_b26e6e _weight-regular_b26e6e _this_2bdcc0 _size-large_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-heading_d6c5f6 _weight-regular_d6c5f6 _this_1e8633 _size-large_1e8633"
   data-testid="Heading"
 >
   Hello world
@@ -83,7 +83,7 @@ exports[`Heading > it works with weights 1`] = `
 
 exports[`Heading > it works with weights 2`] = `
 <h1
-  class="_this_b26e6e _size-medium_b26e6e _family-heading_b26e6e _weight-medium_b26e6e _this_2bdcc0 _size-large_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-heading_d6c5f6 _weight-medium_d6c5f6 _this_1e8633 _size-large_1e8633"
   data-testid="Heading"
 >
   Hello world
@@ -92,7 +92,7 @@ exports[`Heading > it works with weights 2`] = `
 
 exports[`Heading > it works with weights 3`] = `
 <h1
-  class="_this_b26e6e _size-medium_b26e6e _family-heading_b26e6e _weight-bold_b26e6e _this_2bdcc0 _size-large_2bdcc0"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-heading_d6c5f6 _weight-bold_d6c5f6 _this_1e8633 _size-large_1e8633"
   data-testid="Heading"
 >
   Hello world

--- a/src/components/Link/__snapshots__/Link.spec.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.spec.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`Link > it works with defaults 1`] = `
 <a
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c"
   data-testid="Link"
   href="#"
 >
   <span
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
     data-testid="Link-inner"
   >
     Hello world
@@ -17,17 +17,17 @@ exports[`Link > it works with defaults 1`] = `
 
 exports[`Link > it works with icon 1`] = `
 <a
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c"
   data-testid="Link"
   href="#"
 >
   <span
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
     data-testid="Link-inner"
   >
     <svg
       aria-hidden="true"
-      class="svg-inline--fa fa-xmark _icon_a14c64"
+      class="svg-inline--fa fa-xmark _icon_ef752c"
       data-icon="xmark"
       data-prefix="fas"
       focusable="false"
@@ -47,12 +47,12 @@ exports[`Link > it works with icon 1`] = `
 
 exports[`Link > it works with sizes 1`] = `
 <a
-  class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64"
+  class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c"
   data-testid="Link"
   href="#"
 >
   <span
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
     data-testid="Link-inner"
   >
     Hello world
@@ -62,12 +62,12 @@ exports[`Link > it works with sizes 1`] = `
 
 exports[`Link > it works with sizes 2`] = `
 <a
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c"
   data-testid="Link"
   href="#"
 >
   <span
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
     data-testid="Link-inner"
   >
     Hello world
@@ -77,12 +77,12 @@ exports[`Link > it works with sizes 2`] = `
 
 exports[`Link > it works with sizes 3`] = `
 <a
-  class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64"
+  class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c"
   data-testid="Link"
   href="#"
 >
   <span
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
     data-testid="Link-inner"
   >
     Hello world

--- a/src/components/Logo/__snapshots__/Logo.spec.tsx.snap
+++ b/src/components/Logo/__snapshots__/Logo.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Logo > it works 1`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _this_f7d212 _animation-fade_f7d212"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _this_5ff345 _animation-fade_5ff345"
   data-testid="Logo"
 >
   <svg
@@ -10,15 +10,15 @@ exports[`Logo > it works 1`] = `
     viewBox="0 0 64 64"
   >
     <polygon
-      class="_a_f7d212"
+      class="_a_5ff345"
       points="0,0 0,32 32,32"
     />
     <polygon
-      class="_b_f7d212"
+      class="_b_5ff345"
       points="0,32 0,64 32,64"
     />
     <polygon
-      class="_c_f7d212"
+      class="_c_5ff345"
       points="32,0 32,64 64,32"
     />
   </svg>
@@ -27,7 +27,7 @@ exports[`Logo > it works 1`] = `
 
 exports[`Logo > it works with animations 1`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _this_f7d212 _animation-fade_f7d212"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _this_5ff345 _animation-fade_5ff345"
   data-testid="Logo"
 >
   <svg
@@ -35,15 +35,15 @@ exports[`Logo > it works with animations 1`] = `
     viewBox="0 0 64 64"
   >
     <polygon
-      class="_a_f7d212"
+      class="_a_5ff345"
       points="0,0 0,32 32,32"
     />
     <polygon
-      class="_b_f7d212"
+      class="_b_5ff345"
       points="0,32 0,64 32,64"
     />
     <polygon
-      class="_c_f7d212"
+      class="_c_5ff345"
       points="32,0 32,64 64,32"
     />
   </svg>
@@ -52,7 +52,7 @@ exports[`Logo > it works with animations 1`] = `
 
 exports[`Logo > it works with animations 2`] = `
 <div
-  class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _this_f7d212 _animation-slide_f7d212"
+  class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _this_5ff345 _animation-slide_5ff345"
   data-testid="Logo"
 >
   <svg
@@ -60,15 +60,15 @@ exports[`Logo > it works with animations 2`] = `
     viewBox="0 0 64 64"
   >
     <polygon
-      class="_a_f7d212"
+      class="_a_5ff345"
       points="0,0 0,32 32,32"
     />
     <polygon
-      class="_b_f7d212"
+      class="_b_5ff345"
       points="0,32 0,64 32,64"
     />
     <polygon
-      class="_c_f7d212"
+      class="_c_5ff345"
       points="32,0 32,64 64,32"
     />
   </svg>

--- a/src/components/Tabs/__snapshots__/Tabs.spec.tsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.tsx.snap
@@ -2,28 +2,28 @@
 
 exports[`Tabs > it works with defaults 1`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_40c7a2"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_307da9"
   data-testid="Tabs"
 >
   <ul
-    class="_this_d62db4 _elevation-large_d62db4 _roundness-small_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_40c7a2"
+    class="_this_6f2e26 _elevation-large_6f2e26 _roundness-small_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_307da9"
     data-testid="Tabs-list"
   >
     <li
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-small_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-small_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
       data-testid="Tabs-item"
     >
       <a
-        class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _link_40c7a2"
+        class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _link_307da9"
         data-testid="Tabs-link"
         href="#tab1"
       >
         <span
-          class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+          class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
           data-testid="Link-inner"
         >
           <div
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
             data-testid="Box"
           >
             Tab1
@@ -32,20 +32,20 @@ exports[`Tabs > it works with defaults 1`] = `
       </a>
     </li>
     <li
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-small_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-small_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
       data-testid="Tabs-item"
     >
       <a
-        class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _link_40c7a2"
+        class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _link_307da9"
         data-testid="Tabs-link"
         href="#tab2"
       >
         <span
-          class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+          class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
           data-testid="Link-inner"
         >
           <div
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
             data-testid="Box"
           >
             Tab2
@@ -59,28 +59,28 @@ exports[`Tabs > it works with defaults 1`] = `
 
 exports[`Tabs > it works with sizes 1`] = `
 <div
-  class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_40c7a2"
+  class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_307da9"
   data-testid="Tabs"
 >
   <ul
-    class="_this_d62db4 _elevation-large_d62db4 _roundness-small_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_40c7a2"
+    class="_this_6f2e26 _elevation-large_6f2e26 _roundness-small_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_307da9"
     data-testid="Tabs-list"
   >
     <li
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-small_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-small_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
       data-testid="Tabs-item"
     >
       <a
-        class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _link_40c7a2"
+        class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _link_307da9"
         data-testid="Tabs-link"
         href="#tab1"
       >
         <span
-          class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+          class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
           data-testid="Link-inner"
         >
           <div
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
             data-testid="Box"
           >
             Tab1
@@ -89,20 +89,20 @@ exports[`Tabs > it works with sizes 1`] = `
       </a>
     </li>
     <li
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-small_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-small_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
       data-testid="Tabs-item"
     >
       <a
-        class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _link_40c7a2"
+        class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _link_307da9"
         data-testid="Tabs-link"
         href="#tab2"
       >
         <span
-          class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+          class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
           data-testid="Link-inner"
         >
           <div
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
             data-testid="Box"
           >
             Tab2
@@ -116,28 +116,28 @@ exports[`Tabs > it works with sizes 1`] = `
 
 exports[`Tabs > it works with sizes 2`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_40c7a2"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_307da9"
   data-testid="Tabs"
 >
   <ul
-    class="_this_d62db4 _elevation-large_d62db4 _roundness-small_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_40c7a2"
+    class="_this_6f2e26 _elevation-large_6f2e26 _roundness-small_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_307da9"
     data-testid="Tabs-list"
   >
     <li
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-small_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-small_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
       data-testid="Tabs-item"
     >
       <a
-        class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _link_40c7a2"
+        class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _link_307da9"
         data-testid="Tabs-link"
         href="#tab1"
       >
         <span
-          class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+          class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
           data-testid="Link-inner"
         >
           <div
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
             data-testid="Box"
           >
             Tab1
@@ -146,20 +146,20 @@ exports[`Tabs > it works with sizes 2`] = `
       </a>
     </li>
     <li
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-small_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-small_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
       data-testid="Tabs-item"
     >
       <a
-        class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _link_40c7a2"
+        class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _link_307da9"
         data-testid="Tabs-link"
         href="#tab2"
       >
         <span
-          class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+          class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
           data-testid="Link-inner"
         >
           <div
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
             data-testid="Box"
           >
             Tab2
@@ -173,28 +173,28 @@ exports[`Tabs > it works with sizes 2`] = `
 
 exports[`Tabs > it works with sizes 3`] = `
 <div
-  class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_40c7a2"
+  class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_307da9"
   data-testid="Tabs"
 >
   <ul
-    class="_this_d62db4 _elevation-large_d62db4 _roundness-small_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_40c7a2"
+    class="_this_6f2e26 _elevation-large_6f2e26 _roundness-small_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_307da9"
     data-testid="Tabs-list"
   >
     <li
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-small_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-small_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
       data-testid="Tabs-item"
     >
       <a
-        class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _link_40c7a2"
+        class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _link_307da9"
         data-testid="Tabs-link"
         href="#tab1"
       >
         <span
-          class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+          class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
           data-testid="Link-inner"
         >
           <div
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
             data-testid="Box"
           >
             Tab1
@@ -203,20 +203,20 @@ exports[`Tabs > it works with sizes 3`] = `
       </a>
     </li>
     <li
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-small_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-small_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
       data-testid="Tabs-item"
     >
       <a
-        class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _link_40c7a2"
+        class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _link_307da9"
         data-testid="Tabs-link"
         href="#tab2"
       >
         <span
-          class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+          class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
           data-testid="Link-inner"
         >
           <div
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
             data-testid="Box"
           >
             Tab2

--- a/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`Tag > it works with level 1`] = `
 <span
-  class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_2dd11e _level-primary_2dd11e"
+  class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_68e16a _level-primary_68e16a"
   data-testid="Tag"
 >
   <div
-    class="_this_d62db4 _elevation-small_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-medium_d62db4 _gutterY-small_d62db4 _children_2dd11e"
+    class="_this_6f2e26 _elevation-small_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-medium_6f2e26 _gutterY-small_6f2e26 _children_68e16a"
     data-testid="Box"
   >
     Hello world
@@ -16,11 +16,11 @@ exports[`Tag > it works with level 1`] = `
 
 exports[`Tag > it works with level 2`] = `
 <span
-  class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_2dd11e _level-secondary_2dd11e"
+  class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_68e16a _level-secondary_68e16a"
   data-testid="Tag"
 >
   <div
-    class="_this_d62db4 _elevation-small_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-medium_d62db4 _gutterY-small_d62db4 _children_2dd11e"
+    class="_this_6f2e26 _elevation-small_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-medium_6f2e26 _gutterY-small_6f2e26 _children_68e16a"
     data-testid="Box"
   >
     Hello world
@@ -30,11 +30,11 @@ exports[`Tag > it works with level 2`] = `
 
 exports[`Tag > it works with level 3`] = `
 <span
-  class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_2dd11e _level-tertiary_2dd11e"
+  class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_68e16a _level-tertiary_68e16a"
   data-testid="Tag"
 >
   <div
-    class="_this_d62db4 _elevation-small_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-medium_d62db4 _gutterY-small_d62db4 _children_2dd11e"
+    class="_this_6f2e26 _elevation-small_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-medium_6f2e26 _gutterY-small_6f2e26 _children_68e16a"
     data-testid="Box"
   >
     Hello world
@@ -44,11 +44,11 @@ exports[`Tag > it works with level 3`] = `
 
 exports[`Tag > it works with level 4`] = `
 <span
-  class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_2dd11e _level-danger_2dd11e"
+  class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_68e16a _level-danger_68e16a"
   data-testid="Tag"
 >
   <div
-    class="_this_d62db4 _elevation-small_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-medium_d62db4 _gutterY-small_d62db4 _children_2dd11e"
+    class="_this_6f2e26 _elevation-small_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-medium_6f2e26 _gutterY-small_6f2e26 _children_68e16a"
     data-testid="Box"
   >
     Hello world

--- a/src/components/Text/__snapshots__/Text.spec.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Text > it works with defaults 1`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Text"
 >
   Hello world
@@ -11,7 +11,7 @@ exports[`Text > it works with defaults 1`] = `
 
 exports[`Text > it works with families 1`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Text"
 >
   Hello world
@@ -20,7 +20,7 @@ exports[`Text > it works with families 1`] = `
 
 exports[`Text > it works with families 2`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-heading_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-heading_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Text"
 >
   Hello world
@@ -29,7 +29,7 @@ exports[`Text > it works with families 2`] = `
 
 exports[`Text > it works with families 3`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-serif_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-serif_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Text"
 >
   Hello world
@@ -38,7 +38,7 @@ exports[`Text > it works with families 3`] = `
 
 exports[`Text > it works with families 4`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-mono_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-mono_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Text"
 >
   Hello world
@@ -47,7 +47,7 @@ exports[`Text > it works with families 4`] = `
 
 exports[`Text > it works with sizes 1`] = `
 <div
-  class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Text"
 >
   Hello world
@@ -56,7 +56,7 @@ exports[`Text > it works with sizes 1`] = `
 
 exports[`Text > it works with sizes 2`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Text"
 >
   Hello world
@@ -65,7 +65,7 @@ exports[`Text > it works with sizes 2`] = `
 
 exports[`Text > it works with sizes 3`] = `
 <div
-  class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Text"
 >
   Hello world
@@ -74,7 +74,7 @@ exports[`Text > it works with sizes 3`] = `
 
 exports[`Text > it works with weights 1`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Text"
 >
   Hello world
@@ -83,7 +83,7 @@ exports[`Text > it works with weights 1`] = `
 
 exports[`Text > it works with weights 2`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6"
   data-testid="Text"
 >
   Hello world
@@ -92,7 +92,7 @@ exports[`Text > it works with weights 2`] = `
 
 exports[`Text > it works with weights 3`] = `
 <div
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-bold_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-bold_d6c5f6"
   data-testid="Text"
 >
   Hello world

--- a/src/components/Timeline/__snapshots__/Timeline.spec.tsx.snap
+++ b/src/components/Timeline/__snapshots__/Timeline.spec.tsx.snap
@@ -2,15 +2,15 @@
 
 exports[`Timeline > it works with defaults 1`] = `
 <ol
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Timeline"
 >
   <li
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4 _item_254c0f"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26 _item_926827"
     data-testid="Box"
   >
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26"
       data-testid="Box"
     >
       Apr 2021
@@ -18,33 +18,33 @@ exports[`Timeline > it works with defaults 1`] = `
       Present
     </div>
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4 _meta_254c0f"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26 _meta_926827"
       data-testid="Box"
     >
       <div
-        class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e"
+        class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6"
         data-testid="Text"
       >
         Senior Software Engineer
       </div>
       <div
-        class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+        class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
         data-testid="Box"
       >
         <a
-          class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _urlTitle_254c0f"
+          class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _urlTitle_926827"
           data-testid="Link"
           href="https://www.lendinvest.com/"
           rel="noopener noreferrer"
           target="_blank"
         >
           <span
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
             data-testid="Link-inner"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-arrow-up-right-from-square _icon_a14c64"
+              class="svg-inline--fa fa-arrow-up-right-from-square _icon_ef752c"
               data-icon="arrow-up-right-from-square"
               data-prefix="fas"
               focusable="false"
@@ -64,11 +64,11 @@ exports[`Timeline > it works with defaults 1`] = `
     </div>
   </li>
   <li
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4 _item_254c0f"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26 _item_926827"
     data-testid="Box"
   >
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26"
       data-testid="Box"
     >
       Feb 2020
@@ -76,33 +76,33 @@ exports[`Timeline > it works with defaults 1`] = `
       Apr 2021
     </div>
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4 _meta_254c0f"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26 _meta_926827"
       data-testid="Box"
     >
       <div
-        class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e"
+        class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6"
         data-testid="Text"
       >
         Frontend Software Developer
       </div>
       <div
-        class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+        class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
         data-testid="Box"
       >
         <a
-          class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _urlTitle_254c0f"
+          class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _urlTitle_926827"
           data-testid="Link"
           href="https://www.goldencharter.co.uk/"
           rel="noopener noreferrer"
           target="_blank"
         >
           <span
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
             data-testid="Link-inner"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-arrow-up-right-from-square _icon_a14c64"
+              class="svg-inline--fa fa-arrow-up-right-from-square _icon_ef752c"
               data-icon="arrow-up-right-from-square"
               data-prefix="fas"
               focusable="false"
@@ -126,15 +126,15 @@ exports[`Timeline > it works with defaults 1`] = `
 
 exports[`Timeline > it works with sizes 1`] = `
 <ol
-  class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Timeline"
 >
   <li
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-small_d62db4 _item_254c0f"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-small_6f2e26 _item_926827"
     data-testid="Box"
   >
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-small_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-small_6f2e26"
       data-testid="Box"
     >
       Apr 2021
@@ -142,33 +142,33 @@ exports[`Timeline > it works with sizes 1`] = `
       Present
     </div>
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-small_d62db4 _meta_254c0f"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-small_6f2e26 _meta_926827"
       data-testid="Box"
     >
       <div
-        class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-medium_b26e6e"
+        class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6"
         data-testid="Text"
       >
         Senior Software Engineer
       </div>
       <div
-        class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+        class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
         data-testid="Box"
       >
         <a
-          class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _urlTitle_254c0f"
+          class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _urlTitle_926827"
           data-testid="Link"
           href="https://www.lendinvest.com/"
           rel="noopener noreferrer"
           target="_blank"
         >
           <span
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
             data-testid="Link-inner"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-arrow-up-right-from-square _icon_a14c64"
+              class="svg-inline--fa fa-arrow-up-right-from-square _icon_ef752c"
               data-icon="arrow-up-right-from-square"
               data-prefix="fas"
               focusable="false"
@@ -188,11 +188,11 @@ exports[`Timeline > it works with sizes 1`] = `
     </div>
   </li>
   <li
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-small_d62db4 _item_254c0f"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-small_6f2e26 _item_926827"
     data-testid="Box"
   >
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-small_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-small_6f2e26"
       data-testid="Box"
     >
       Feb 2020
@@ -200,33 +200,33 @@ exports[`Timeline > it works with sizes 1`] = `
       Apr 2021
     </div>
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-small_d62db4 _meta_254c0f"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-small_6f2e26 _meta_926827"
       data-testid="Box"
     >
       <div
-        class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-medium_b26e6e"
+        class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6"
         data-testid="Text"
       >
         Frontend Software Developer
       </div>
       <div
-        class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+        class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
         data-testid="Box"
       >
         <a
-          class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _urlTitle_254c0f"
+          class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _urlTitle_926827"
           data-testid="Link"
           href="https://www.goldencharter.co.uk/"
           rel="noopener noreferrer"
           target="_blank"
         >
           <span
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
             data-testid="Link-inner"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-arrow-up-right-from-square _icon_a14c64"
+              class="svg-inline--fa fa-arrow-up-right-from-square _icon_ef752c"
               data-icon="arrow-up-right-from-square"
               data-prefix="fas"
               focusable="false"
@@ -250,15 +250,15 @@ exports[`Timeline > it works with sizes 1`] = `
 
 exports[`Timeline > it works with sizes 2`] = `
 <ol
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Timeline"
 >
   <li
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4 _item_254c0f"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26 _item_926827"
     data-testid="Box"
   >
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26"
       data-testid="Box"
     >
       Apr 2021
@@ -266,33 +266,33 @@ exports[`Timeline > it works with sizes 2`] = `
       Present
     </div>
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4 _meta_254c0f"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26 _meta_926827"
       data-testid="Box"
     >
       <div
-        class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e"
+        class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6"
         data-testid="Text"
       >
         Senior Software Engineer
       </div>
       <div
-        class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+        class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
         data-testid="Box"
       >
         <a
-          class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _urlTitle_254c0f"
+          class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _urlTitle_926827"
           data-testid="Link"
           href="https://www.lendinvest.com/"
           rel="noopener noreferrer"
           target="_blank"
         >
           <span
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
             data-testid="Link-inner"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-arrow-up-right-from-square _icon_a14c64"
+              class="svg-inline--fa fa-arrow-up-right-from-square _icon_ef752c"
               data-icon="arrow-up-right-from-square"
               data-prefix="fas"
               focusable="false"
@@ -312,11 +312,11 @@ exports[`Timeline > it works with sizes 2`] = `
     </div>
   </li>
   <li
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4 _item_254c0f"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26 _item_926827"
     data-testid="Box"
   >
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26"
       data-testid="Box"
     >
       Feb 2020
@@ -324,33 +324,33 @@ exports[`Timeline > it works with sizes 2`] = `
       Apr 2021
     </div>
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-medium_d62db4 _meta_254c0f"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-medium_6f2e26 _meta_926827"
       data-testid="Box"
     >
       <div
-        class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e"
+        class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6"
         data-testid="Text"
       >
         Frontend Software Developer
       </div>
       <div
-        class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+        class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
         data-testid="Box"
       >
         <a
-          class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _urlTitle_254c0f"
+          class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _urlTitle_926827"
           data-testid="Link"
           href="https://www.goldencharter.co.uk/"
           rel="noopener noreferrer"
           target="_blank"
         >
           <span
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
             data-testid="Link-inner"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-arrow-up-right-from-square _icon_a14c64"
+              class="svg-inline--fa fa-arrow-up-right-from-square _icon_ef752c"
               data-icon="arrow-up-right-from-square"
               data-prefix="fas"
               focusable="false"
@@ -374,15 +374,15 @@ exports[`Timeline > it works with sizes 2`] = `
 
 exports[`Timeline > it works with sizes 3`] = `
 <ol
-  class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-regular_b26e6e"
+  class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6"
   data-testid="Timeline"
 >
   <li
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-large_d62db4 _item_254c0f"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-large_6f2e26 _item_926827"
     data-testid="Box"
   >
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-large_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-large_6f2e26"
       data-testid="Box"
     >
       Apr 2021
@@ -390,33 +390,33 @@ exports[`Timeline > it works with sizes 3`] = `
       Present
     </div>
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-large_d62db4 _meta_254c0f"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-large_6f2e26 _meta_926827"
       data-testid="Box"
     >
       <div
-        class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-medium_b26e6e"
+        class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6"
         data-testid="Text"
       >
         Senior Software Engineer
       </div>
       <div
-        class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+        class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
         data-testid="Box"
       >
         <a
-          class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _urlTitle_254c0f"
+          class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _urlTitle_926827"
           data-testid="Link"
           href="https://www.lendinvest.com/"
           rel="noopener noreferrer"
           target="_blank"
         >
           <span
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
             data-testid="Link-inner"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-arrow-up-right-from-square _icon_a14c64"
+              class="svg-inline--fa fa-arrow-up-right-from-square _icon_ef752c"
               data-icon="arrow-up-right-from-square"
               data-prefix="fas"
               focusable="false"
@@ -436,11 +436,11 @@ exports[`Timeline > it works with sizes 3`] = `
     </div>
   </li>
   <li
-    class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-large_d62db4 _item_254c0f"
+    class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-large_6f2e26 _item_926827"
     data-testid="Box"
   >
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-large_d62db4"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-large_6f2e26"
       data-testid="Box"
     >
       Feb 2020
@@ -448,33 +448,33 @@ exports[`Timeline > it works with sizes 3`] = `
       Apr 2021
     </div>
     <div
-      class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-large_d62db4 _meta_254c0f"
+      class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-large_6f2e26 _meta_926827"
       data-testid="Box"
     >
       <div
-        class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-medium_b26e6e"
+        class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6"
         data-testid="Text"
       >
         Frontend Software Developer
       </div>
       <div
-        class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4"
+        class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26"
         data-testid="Box"
       >
         <a
-          class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-regular_b26e6e _this_a14c64 _urlTitle_254c0f"
+          class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-regular_d6c5f6 _this_ef752c _urlTitle_926827"
           data-testid="Link"
           href="https://www.goldencharter.co.uk/"
           rel="noopener noreferrer"
           target="_blank"
         >
           <span
-            class="_this_d62db4 _elevation-none_d62db4 _roundness-none_d62db4 _gutter-none_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_a14c64"
+            class="_this_6f2e26 _elevation-none_6f2e26 _roundness-none_6f2e26 _gutter-none_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_ef752c"
             data-testid="Link-inner"
           >
             <svg
               aria-hidden="true"
-              class="svg-inline--fa fa-arrow-up-right-from-square _icon_a14c64"
+              class="svg-inline--fa fa-arrow-up-right-from-square _icon_ef752c"
               data-icon="arrow-up-right-from-square"
               data-prefix="fas"
               focusable="false"

--- a/src/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -2,17 +2,17 @@
 
 exports[`Toggle > it works disabled 1`] = `
 <label
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_dc1479 _disabled_dc1479"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_9a3373 _disabled_9a3373"
   data-testid="Toggle"
   for=":rg:"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_dc1479 _level-primary_dc1479"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_9a3373 _level-primary_9a3373"
     data-testid="Toggle-inner"
   >
     <input
       aria-describedby=":rh:"
-      class="_checkbox_dc1479"
+      class="_checkbox_9a3373"
       disabled=""
       id=":rg:"
       type="checkbox"
@@ -43,17 +43,17 @@ exports[`Toggle > it works disabled 1`] = `
 
 exports[`Toggle > it works with defaults 1`] = `
 <label
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_dc1479"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_9a3373"
   data-testid="Toggle"
   for=":r0:"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_dc1479 _level-primary_dc1479"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_9a3373 _level-primary_9a3373"
     data-testid="Toggle-inner"
   >
     <input
       aria-describedby=":r1:"
-      class="_checkbox_dc1479"
+      class="_checkbox_9a3373"
       id=":r0:"
       type="checkbox"
     />
@@ -83,17 +83,17 @@ exports[`Toggle > it works with defaults 1`] = `
 
 exports[`Toggle > it works with levels 1`] = `
 <label
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_dc1479"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_9a3373"
   data-testid="Toggle"
   for=":r8:"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_dc1479 _level-primary_dc1479"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_9a3373 _level-primary_9a3373"
     data-testid="Toggle-inner"
   >
     <input
       aria-describedby=":r9:"
-      class="_checkbox_dc1479"
+      class="_checkbox_9a3373"
       id=":r8:"
       type="checkbox"
     />
@@ -123,17 +123,17 @@ exports[`Toggle > it works with levels 1`] = `
 
 exports[`Toggle > it works with levels 2`] = `
 <label
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_dc1479"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_9a3373"
   data-testid="Toggle"
   for=":ra:"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_dc1479 _level-secondary_dc1479"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_9a3373 _level-secondary_9a3373"
     data-testid="Toggle-inner"
   >
     <input
       aria-describedby=":rb:"
-      class="_checkbox_dc1479"
+      class="_checkbox_9a3373"
       id=":ra:"
       type="checkbox"
     />
@@ -163,17 +163,17 @@ exports[`Toggle > it works with levels 2`] = `
 
 exports[`Toggle > it works with levels 3`] = `
 <label
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_dc1479"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_9a3373"
   data-testid="Toggle"
   for=":rc:"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_dc1479 _level-tertiary_dc1479"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_9a3373 _level-tertiary_9a3373"
     data-testid="Toggle-inner"
   >
     <input
       aria-describedby=":rd:"
-      class="_checkbox_dc1479"
+      class="_checkbox_9a3373"
       id=":rc:"
       type="checkbox"
     />
@@ -203,17 +203,17 @@ exports[`Toggle > it works with levels 3`] = `
 
 exports[`Toggle > it works with levels 4`] = `
 <label
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_dc1479"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_9a3373"
   data-testid="Toggle"
   for=":re:"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_dc1479 _level-danger_dc1479"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_9a3373 _level-danger_9a3373"
     data-testid="Toggle-inner"
   >
     <input
       aria-describedby=":rf:"
-      class="_checkbox_dc1479"
+      class="_checkbox_9a3373"
       id=":re:"
       type="checkbox"
     />
@@ -243,17 +243,17 @@ exports[`Toggle > it works with levels 4`] = `
 
 exports[`Toggle > it works with sizes 1`] = `
 <label
-  class="_this_b26e6e _size-small_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_dc1479"
+  class="_this_d6c5f6 _size-small_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_9a3373"
   data-testid="Toggle"
   for=":r2:"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-small_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_dc1479 _level-primary_dc1479"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-small_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_9a3373 _level-primary_9a3373"
     data-testid="Toggle-inner"
   >
     <input
       aria-describedby=":r3:"
-      class="_checkbox_dc1479"
+      class="_checkbox_9a3373"
       id=":r2:"
       type="checkbox"
     />
@@ -283,17 +283,17 @@ exports[`Toggle > it works with sizes 1`] = `
 
 exports[`Toggle > it works with sizes 2`] = `
 <label
-  class="_this_b26e6e _size-medium_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_dc1479"
+  class="_this_d6c5f6 _size-medium_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_9a3373"
   data-testid="Toggle"
   for=":r4:"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-medium_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_dc1479 _level-primary_dc1479"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-medium_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_9a3373 _level-primary_9a3373"
     data-testid="Toggle-inner"
   >
     <input
       aria-describedby=":r5:"
-      class="_checkbox_dc1479"
+      class="_checkbox_9a3373"
       id=":r4:"
       type="checkbox"
     />
@@ -323,17 +323,17 @@ exports[`Toggle > it works with sizes 2`] = `
 
 exports[`Toggle > it works with sizes 3`] = `
 <label
-  class="_this_b26e6e _size-large_b26e6e _family-body_b26e6e _weight-medium_b26e6e _this_dc1479"
+  class="_this_d6c5f6 _size-large_d6c5f6 _family-body_d6c5f6 _weight-medium_d6c5f6 _this_9a3373"
   data-testid="Toggle"
   for=":r6:"
 >
   <span
-    class="_this_d62db4 _elevation-medium_d62db4 _roundness-none_d62db4 _gutter-large_d62db4 _gutterX-none_d62db4 _gutterY-none_d62db4 _inner_dc1479 _level-primary_dc1479"
+    class="_this_6f2e26 _elevation-medium_6f2e26 _roundness-none_6f2e26 _gutter-large_6f2e26 _gutterX-none_6f2e26 _gutterY-none_6f2e26 _inner_9a3373 _level-primary_9a3373"
     data-testid="Toggle-inner"
   >
     <input
       aria-describedby=":r7:"
-      class="_checkbox_dc1479"
+      class="_checkbox_9a3373"
       id=":r6:"
       type="checkbox"
     />


### PR DESCRIPTION
## Types of Changes
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Upgraded Vitest to v3 introduced new hashed CSS class names, causing snapshot mismatches. Regenerated all component snapshots to resolve the failing tests.

------
https://chatgpt.com/codex/tasks/task_e_6849ddf8f67883288be38bc2d0db2471